### PR TITLE
tests without nose/psycopg2

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,43 +1,30 @@
 #!/usr/bin/env python
-import sys
 from optparse import OptionParser
-
 from django.conf import settings
-
-if not settings.configured:
-    settings.configure(
-        DATABASE_ENGINE='django.db.backends.postgresql_psycopg2',
-        DATABASE_NAME='bitfield_test',
-        INSTALLED_APPS=[
-            'django.contrib.contenttypes',
-            'bitfield',
-            'bitfield.tests',
-        ],
-        ROOT_URLCONF='',
-        DEBUG=False,
-    )
+from django.core.management import call_command, setup_environ
 
 
-from django_nose import NoseTestSuiteRunner
 
-
-def runtests(*test_args, **kwargs):
-    if 'south' in settings.INSTALLED_APPS:
-        from south.management.commands import patch_for_test_db_setup
-        patch_for_test_db_setup()
-
-    if not test_args:
-        test_args = ['bitfield']
-
-    test_runner = NoseTestSuiteRunner(**kwargs)
-
-    failures = test_runner.run_tests(test_args)
-    sys.exit(failures)
+def runtests(*test_args, **options):
+    if not settings.configured:
+        settings.configure(
+            DATABASES = {
+                'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory;'}
+            },
+            INSTALLED_APPS=[
+                'bitfield',
+                'bitfield.tests',
+            ],
+            ROOT_URLCONF='',
+            DEBUG=False,
+        )
+    setup_environ(settings)
+    # Fire off the tests
+    call_command('test', 'bitfield', *test_args, **options)
 
 if __name__ == '__main__':
     parser = OptionParser()
     parser.add_option('--verbosity', dest='verbosity', action='store', default=1, type=int)
-    parser.add_options(NoseTestSuiteRunner.options)
     (options, args) = parser.parse_args()
 
     runtests(*args, **options.__dict__)

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,6 @@ setup(
     install_requires=[
         'Django>=1.2,<1.4',
     ],
-    setup_requires=[
-        'nose>=1.0',
-    ],
-    tests_require=[
-        'django-nose==0.1.3',
-        'psycopg2==2.3',
-    ],
     test_suite='runtests.runtests',
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
I had trouble to setup a virtualenv on osx so I have removed:
- nose dependency
- psycopg2 dependency

tests pass even when using django.db.backends.sqlite3 in memory
