### PR TITLE
use of self.column instead of self.db_column

### DIFF
--- a/bitfield/models.py
+++ b/bitfield/models.py
@@ -117,7 +117,7 @@ class BitField(BigIntegerField):
         if isinstance(value, SQLEvaluator) and isinstance(value.expression, Bit):
             value = value.expression
         if isinstance(value, (BitHandler, Bit)):
-            return BitQueryLookupWrapper(self.model._meta.db_table, self.db_column or self.name, value)
+            return BitQueryLookupWrapper(self.model._meta.db_table, self.column, value)
         return BigIntegerField.get_db_prep_lookup(self, lookup_type=lookup_type, value=value,
                                                         connection=connection, prepared=prepared)
 

--- a/bitfield/tests/tests.py
+++ b/bitfield/tests/tests.py
@@ -140,8 +140,7 @@ class BitFieldTest(TestCase):
 
         cursor = connection.cursor()
         flags_field = BitFieldTestModel._meta.get_field_by_name('flags')[0]
-        flags_db_column = flags_field.db_column or flags_field.name
-        cursor.execute("INSERT INTO %s (%s) VALUES (-1)" % (BitFieldTestModel._meta.db_table, flags_db_column));
+        cursor.execute("INSERT INTO %s (%s) VALUES (-1)" % (BitFieldTestModel._meta.db_table, flags_field.column))
         # There should only be the one row we inserted through the cursor.
         instance = BitFieldTestModel.objects.get(flags=-1)
         self.assertTrue(instance.flags.FLAG_0)


### PR DESCRIPTION
Reading Pro Django I saw that a self.column exists so it's better to use it instead of recalculating it
