### PR TITLE
Added support for null=True (and default=None) to BitField class.

### DIFF
--- a/bitfield/models.py
+++ b/bitfield/models.py
@@ -57,7 +57,8 @@ class BitFieldCreator(Creator):
         if obj is None:
             return BitFieldFlags(self.field.flags)
         retval = obj.__dict__[self.field.name]
-        if self.field.__class__ is BitField:
+        # handle case where value of field is None
+        if not retval is None and self.field.__class__ is BitField:
             # Update flags from class in case they've changed.
             retval._keys = self.field.flags
         return retval
@@ -106,7 +107,11 @@ class BitField(BigIntegerField):
     def get_prep_value(self, value):
         if isinstance(value, (BitHandler, Bit)):
             value = value.mask
-        return int(value)
+        # handle case where value is None
+        if value is not None:
+            return int(value)
+        else:
+            return value
 
     # def get_db_prep_save(self, value, connection):
     #     if isinstance(value, Bit):
@@ -133,7 +138,10 @@ class BitField(BigIntegerField):
     def to_python(self, value):
         if isinstance(value, Bit):
             value = value.mask
-        if not isinstance(value, BitHandler):
+        # handle case where value is None
+        if value is None:
+            pass
+        elif not isinstance(value, BitHandler):
             # Regression for #1425: fix bad data that was created resulting
             # in negative values for flags.  Compute the value that would
             # have been visible ot the application to preserve compatibility.

--- a/bitfield/tests/models.py
+++ b/bitfield/tests/models.py
@@ -28,3 +28,10 @@ class CompositeBitFieldTestModel(models.Model):
         'flags_2',
     ))
 
+class BitFieldNullDefaultModel(models.Model):
+    flags = BitField(flags=(
+        'FLAG_0',
+        'FLAG_1',
+        'FLAG_2',
+        'FLAG_3',
+    ), null=True, default=None, db_column='another_default_null_name')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-bitfield',
-    version='1.5.0',
+    version='1.5.0.ejs',
     author='DISQUS',
     author_email='opensource@disqus.com',
     url='http://github.com/disqus/django-bitfield',


### PR DESCRIPTION
Also added a test that checks creation and manipulation of model instances with a BitField that uses null=True and default=None.  

Prior to this change, the following model definition would not work:

```
class Foo(models.Model):
     flags=BitField(flags=FLAGS, null=True, default=None)
```

the resulting instances would ignore the default None, and have fields with BitHandler instances with all bits disabled.  

Now, BitField fields can either be None (null) or BitHandler instances.
