### PR TITLE
Fixed BitFieldCheckboxSelectMultiple rendering with POST data

### DIFF
--- a/bitfield/forms.py
+++ b/bitfield/forms.py
@@ -6,7 +6,7 @@ from .types import BitHandler
 
 class BitFieldCheckboxSelectMultiple(CheckboxSelectMultiple):
     def render(self, name, value, attrs=None, choices=()):
-        if value is not None:
+        if type(value) is BitHandler:
             value = [k for k, v in value if v]
         return super(BitFieldCheckboxSelectMultiple, self).render(
           name, value, attrs=attrs, choices=enumerate(choices))


### PR DESCRIPTION
There is a bug on form render with data from POST.

The widget render function unpacks value from a model BitHandler, but when a form is not valid the function gets a list of strings.
