### PR TITLE
Check limits & dict initialization

### DIFF
--- a/bitfield/models.py
+++ b/bitfield/models.py
@@ -96,6 +96,14 @@ class BitField(BigIntegerField):
     __metaclass__ = BitFieldMeta
 
     def __init__(self, flags, *args, **kwargs):
+        if isinstance(flags, dict):
+            # Get only integer keys in correct range
+            valid_keys = (k for k in flags.keys() if isinstance(k, int) and (0 <= k < MAX_FLAG_COUNT))
+            if not valid_keys:
+                raise ValueError('Wrong keys or empty dictionary')
+            # Fill list with values from dict or with empty values
+            flags = [flags.get(i, '') for i in range(max(valid_keys) + 1)]
+
         if len(flags) > MAX_FLAG_COUNT:
             raise ValueError('Too many flags')
 

--- a/bitfield/tests/tests.py
+++ b/bitfield/tests/tests.py
@@ -255,6 +255,29 @@ class BitFieldTest(TestCase):
 
         self.assertRaises(ValueError, BitField, flags=flags[:(MAX_COUNT + 1)])
 
+    def test_dictionary_init(self):
+        flags = {
+            0: 'zero',
+            1: 'first',
+            10: 'tenth',
+            2: 'second',
+
+            'wrongkey': 'wrongkey',
+            100: 'bigkey',
+            -100: 'smallkey',
+        }
+
+        try:
+            bf = BitField(flags)
+        except ValueError:
+            self.fail("It should work well with these flags")
+
+        self.assertEquals(bf.flags, ['zero', 'first', 'second', '', '', '', '', '', '', '', 'tenth'])
+        self.assertRaises(ValueError, BitField, flags={})
+        self.assertRaises(ValueError, BitField, flags={'wrongkey': 'wrongkey'})
+        self.assertRaises(ValueError, BitField, flags={'1': 'non_int_key'})
+
+
 class BitFieldSerializationTest(TestCase):
     def test_adding_flags(self):
         import pickle


### PR DESCRIPTION
Two different, but dependent features:
#### Check limits

Check count of flags and raise error if BigIntegerField can't handle it correctly.
#### Dictionary initialization

Initialization with dictionary with integer keys. Safer in case of refactoring, flags meaning depends on constant key, not on its position.

``` python
from bitfield import BitField

class MyModel(models.Model):
    flags = BitField(flags={
        0: 'awesome_flag',
        1: 'flaggy_foo',
        #2-9 reserved for future use
        11: 'wrong_place_added_key',  # added on refactoring
        10: 'baz_bar',
    })
```
