### PR TITLE
Flag labels support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,15 @@ First you'll need to attach a BitField to your class. This acts as a BigIntegerF
 	        'baz_bar',
 	    ))
 
+Flags can also be defined with labels::
+
+	class MyModel(models.Model):
+	    flags = BitField(flags=(
+	        ('awesome_flag', 'Awesome Flag!'),
+	        ('flaggy_foo', 'Flaggy Foo'),
+	        ('baz_bar', 'Baz (bar)'),
+	    ))
+
 Now you can use the field using very familiar Django operations::
 
 	# Create the model
@@ -62,6 +71,9 @@ Now you can use the field using very familiar Django operations::
 	# List all flags on the field
 	for f in o.flags:
 	    print f
+
+	# Get a flag label
+	print o.flags.get_label('awesome_flag')
 
 Enjoy!
 

--- a/bitfield/admin.py
+++ b/bitfield/admin.py
@@ -13,6 +13,7 @@ class BitFieldListFilter(FieldListFilter):
         self.lookup_kwarg = field_path
         self.lookup_val = int(request.GET.get(self.lookup_kwarg, 0))
         self.flags = field.flags
+        self.labels = field.labels
         super(BitFieldListFilter, self).__init__(field,
             request, params, model, model_admin, field_path)
 
@@ -33,5 +34,5 @@ class BitFieldListFilter(FieldListFilter):
                 'query_string': cl.get_query_string({
                         self.lookup_kwarg: bit_mask,
                     }),
-                'display': flag,
+                'display': self.labels[number],
             }

--- a/bitfield/types.py
+++ b/bitfield/types.py
@@ -105,13 +105,14 @@ class BitHandler(object):
     """
     Represents an array of bits, each as a ``Bit`` object.
     """
-    def __init__(self, value, keys):
+    def __init__(self, value, keys, labels=None):
         # TODO: change to bitarray?
         if value:
             self._value = int(value)
         else:
             self._value = 0
         self._keys = keys
+        self._labels = labels is not None and labels or keys
 
     def __eq__(self, other):
         if not isinstance(other, BitHandler):
@@ -209,3 +210,10 @@ class BitHandler(object):
     def iteritems(self):
         for k in self._keys:
             yield (k, getattr(self, k).is_set)
+
+    def get_label(self, flag):
+        if isinstance(flag, basestring):
+            flag = self._keys.index(flag)
+        if isinstance(flag, Bit):
+            flag = flag.number
+        return self._labels[flag]


### PR DESCRIPTION
It would be nice to be able to specify human-readable labels for your flags. This patch adds support for that, similar to how one might specify field choices (except this does not act as actual field.choices).  It should be completely backward compatible without breaking anything. Thoughts?
