### PR TITLE
Removed Bit.prepare() and BitHandler.prepare()

### DIFF
--- a/bitfield/types.py
+++ b/bitfield/types.py
@@ -94,9 +94,6 @@ class Bit(object):
     def __sentry__(self):
         return repr(self)
 
-    def prepare(self, evaluator, query, allow_joins):
-        return self
-
     def evaluate(self, evaluator, qn, connection):
         return self.mask, []
 
@@ -178,9 +175,6 @@ class BitHandler(object):
     def _get_mask(self):
         return self._value
     mask = property(_get_mask)
-
-    def prepare(self, evaluator, query, allow_joins):
-        return self
 
     def evaluate(self, evaluator, qn, connection):
         return self.mask, []


### PR DESCRIPTION
They can cause problems because they don't match the number of args expected by Field.get_prep_lookup().

All included tests pass.

Discussed this solution with David Cramer in #sentry on freenode.
