### PR TITLE
fix BitFieldCheckboxSelectMultiple for new form

### DIFF
--- a/bitfield/forms.py
+++ b/bitfield/forms.py
@@ -8,6 +8,15 @@ class BitFieldCheckboxSelectMultiple(CheckboxSelectMultiple):
     def render(self, name, value, attrs=None, choices=()):
         if isinstance(value, BitHandler):
             value = [k for k, v in value if v]
+        elif isinstance(value, int):
+            real_value=[]
+            div=2
+            for (k,v) in self.choices:
+                if value % div != 0:
+                    real_value.append(k)
+                    value -= (value % div)
+                div*=2
+            value=real_value
         return super(BitFieldCheckboxSelectMultiple, self).render(
             name, value, attrs=attrs, choices=enumerate(choices))
 

--- a/bitfield/forms.py
+++ b/bitfield/forms.py
@@ -9,14 +9,14 @@ class BitFieldCheckboxSelectMultiple(CheckboxSelectMultiple):
         if isinstance(value, BitHandler):
             value = [k for k, v in value if v]
         elif isinstance(value, int):
-            real_value=[]
-            div=2
-            for (k,v) in self.choices:
+            real_value = []
+            div = 2
+            for (k, v) in self.choices:
                 if value % div != 0:
                     real_value.append(k)
                     value -= (value % div)
-                div*=2
-            value=real_value
+                div *= 2
+            value = real_value
         return super(BitFieldCheckboxSelectMultiple, self).render(
             name, value, attrs=attrs, choices=enumerate(choices))
 


### PR DESCRIPTION
In the admin, when creating a new form, the default is the integer version of the value, which cannot be looped over in CheckboxSelectMultiple.render() (raises an Error). This converts the integer value to Array. Works with default=X, X being an integer or an array of flags.