### PR TITLE
Implement deconstruct() for Django 1.7 migrations support

### DIFF
--- a/bitfield/models.py
+++ b/bitfield/models.py
@@ -144,6 +144,8 @@ class BitField(six.with_metaclass(BitFieldMeta, BigIntegerField)):
         return value
 
     def get_prep_value(self, value):
+        if value is None:
+            return None
         if isinstance(value, (BitHandler, Bit)):
             value = value.mask
         return int(value)


### PR DESCRIPTION
See https://docs.djangoproject.com/en/dev/releases/1.7/#deconstruct-and-serializability

An alternative implementation would be to use the `deconstructible` decorator from `django.utils.deconstruct` on the field.

Without this, `manage.py syncdb` fails with

```
TypeError: Couldn't reconstruct field foo on bar.baz: __init__() takes at least 2 arguments (2 given)
```
