### PR TITLE
Implement __cmp__ to BitHandler

### DIFF
--- a/bitfield/types.py
+++ b/bitfield/types.py
@@ -122,6 +122,9 @@ class BitHandler(object):
             return False
         return self._value == other._value
 
+    def __cmp__(self, other):
+        return self._value.__cmp__(int(other))
+
     def __repr__(self):
         return '<%s: %s>' % (self.__class__.__name__, ', '.join('%s=%s' % (k, self.get_bit(n).is_set) for n, k in enumerate(self._keys)),)
 


### PR DESCRIPTION
This allows to BitField form field to be compared with IntegerField
max_value validator.

Without it form with BitField always returns error:

```
Ensure this value is less than or equal to 9223372036854775807.
```
