### PR TITLE
FIX: BitHandler.__cmp__ on 32bit systems

### DIFF
--- a/bitfield/types.py
+++ b/bitfield/types.py
@@ -123,7 +123,7 @@ class BitHandler(object):
         return self._value == other._value
 
     def __cmp__(self, other):
-        return self._value.__cmp__(int(other))
+        return cmp(self._value, other)
 
     def __repr__(self):
         return '<%s: %s>' % (self.__class__.__name__, ', '.join('%s=%s' % (k, self.get_bit(n).is_set) for n, k in enumerate(self._keys)),)


### PR DESCRIPTION
> > > BitHandler(1, ('FLAG_0',)) < 9223372036854775807
> > > TypeError: int.**cmp**(x,y) requires y to be a 'int', not a 'long'
