### PR TITLE
Ensure total ordering for the BitHandler (Python3 compat).

### DIFF
--- a/bitfield/admin.py
+++ b/bitfield/admin.py
@@ -22,7 +22,7 @@ class BitFieldListFilter(FieldListFilter):
             field, request, params, model, model_admin, field_path)
 
     def queryset(self, request, queryset):
-        filter = dict((p, bitor(F(p), v)) for p, v in self.used_parameters.iteritems())
+        filter = dict((p, bitor(F(p), v)) for p, v in self.used_parameters.items())
         try:
             return queryset.filter(**filter)
         except ValidationError as e:

--- a/bitfield/models.py
+++ b/bitfield/models.py
@@ -159,7 +159,7 @@ class BitField(six.with_metaclass(BitFieldMeta, BigIntegerField)):
         if isinstance(value, SQLEvaluator) and isinstance(value.expression, Bit):
             value = value.expression
         if isinstance(value, (BitHandler, Bit)):
-            return BitQueryLookupWrapper(self.model._meta.db_table, self.db_column or self.name, value)
+            return [value.mask]
         return BigIntegerField.get_db_prep_lookup(self, lookup_type=lookup_type, value=value,
                                                   connection=connection, prepared=prepared)
 
@@ -195,6 +195,9 @@ class BitField(six.with_metaclass(BitFieldMeta, BigIntegerField)):
         name, path, args, kwargs = super(BitField, self).deconstruct()
         args.insert(0, self._arg_flags)
         return name, path, args, kwargs
+
+
+BitField.register_lookup(BitQueryLookupWrapper)
 
 
 class CompositeBitFieldWrapper(object):

--- a/bitfield/tests/tests.py
+++ b/bitfield/tests/tests.py
@@ -100,10 +100,12 @@ class BitHandlerTest(TestCase):
 
     def test_total_ordering(self):
         bithandler = BitHandler(0, ('FLAG_0', 'FLAG_1', 'FLAG_2', 'FLAG_3'))
-        self.assertLess(bithandler, int(bithandler) + 1)
-        self.assertLessEqual(bithandler, int(bithandler))
-        self.assertGreaterEqual(bithandler, int(bithandler))
-        self.assertGreater(bithandler, int(bithandler) - 1)
+        # Don't use assertLess, assertGreater since those are not available for
+        # django 1.2
+        self.assertTrue(bithandler < int(bithandler) + 1)
+        self.assertTrue(bithandler <= int(bithandler))
+        self.assertTrue(bithandler >= int(bithandler))
+        self.assertTrue(bithandler > int(bithandler) - 1)
 
 
 class BitTest(TestCase):

--- a/bitfield/tests/tests.py
+++ b/bitfield/tests/tests.py
@@ -98,6 +98,13 @@ class BitHandlerTest(TestCase):
         self.assertEquals(bithandler.FLAG_1, True)
         self.assertEquals(bithandler.FLAG_2, False)
 
+    def test_total_ordering(self):
+        bithandler = BitHandler(0, ('FLAG_0', 'FLAG_1', 'FLAG_2', 'FLAG_3'))
+        self.assertLess(bithandler, int(bithandler) + 1)
+        self.assertLessEqual(bithandler, int(bithandler))
+        self.assertGreaterEqual(bithandler, int(bithandler))
+        self.assertGreater(bithandler, int(bithandler) - 1)
+
 
 class BitTest(TestCase):
     def test_int(self):

--- a/bitfield/types.py
+++ b/bitfield/types.py
@@ -125,6 +125,18 @@ class BitHandler(object):
     def __cmp__(self, other):
         return cmp(self._value, other)
 
+    def __lt__(self, other):
+        return self._value < other
+
+    def __le__(self, other):
+        return self._value <= other
+
+    def __gt__(self, other):
+        return self._value > other
+
+    def __ge__(self, other):
+        return self._value >= other
+
     def __repr__(self):
         return '<%s: %s>' % (self.__class__.__name__, ', '.join('%s=%s' % (k, self.get_bit(n).is_set) for n, k in enumerate(self._keys)),)
 

--- a/runtests.py
+++ b/runtests.py
@@ -2,6 +2,7 @@
 import sys
 from optparse import OptionParser
 
+import django
 from django.conf import settings
 
 if not settings.configured:
@@ -21,6 +22,7 @@ if not settings.configured:
         ROOT_URLCONF='',
         DEBUG=False,
     )
+    django.setup()
 
 
 from django_nose import NoseTestSuiteRunner

--- a/runtests.py
+++ b/runtests.py
@@ -22,6 +22,8 @@ if not settings.configured:
         ROOT_URLCONF='',
         DEBUG=False,
     )
+
+if django.VERSION > (1, 7):
     django.setup()
 
 


### PR DESCRIPTION
Hello,

This pull request ensure Python3 compatibility for django-bitfield. I'm currently using the bitfield in a project of mine that requires django 1.7 and Python 3.4.

The current bitfield implementation does not work on Python3 since whe submitting a form with a bitfield in it the following exception is raised:

unorderable types: BitHandler() < int()

This is caused because __cmp__ is gone in Python3, for references see[0]:

"""The cmp() function should be treated as gone, and the __cmp__() special method is no longer supported. Use __lt__() for sorting, __eq__() with __hash__(), and other rich comparisons as needed. (If you really need the cmp() functionality, you could use the expression (a > b) - (a < b) as the equivalent for cmp(a, b).)"""

Thanks.

[0] https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons