### PR TITLE
Update types.py

### DIFF
--- a/bitfield/types.py
+++ b/bitfield/types.py
@@ -122,6 +122,18 @@ class BitHandler(object):
             return False
         return self._value == other._value
 
+    def __lt__(self, other):
+        return int(self._value) < other
+    
+    def __le__(self, other):
+        return int(self._value) <= other
+    
+    def __gt__(self, other):
+        return int(self._value) > other
+    
+    def __ge__(self, other):
+        return int(self._value) >= other
+
     def __cmp__(self, other):
         return cmp(self._value, other)
 


### PR DESCRIPTION
Added greater than and less than comparisons so the BitHandler's value is an int during numeric comparison.  This fixes issue in Django 1.7.1 where the MaxValueValidator and MinValueValidator's try comparing a BitHandler with an int and the MaxValueValidator always reports the value as being greater.