### PR TITLE
clean() in forms fails if a value that is not ascii is selected

### DIFF
--- a/bitfield/forms.py
+++ b/bitfield/forms.py
@@ -40,7 +40,10 @@ class BitFormField(IntegerField):
         result = BitHandler(0, [k for k, v in self.choices])
         for k in value:
             try:
-                setattr(result, str(k), True)
+                try:
+                    setattr(result, unicode(k).encode("utf8"), True)
+                except NameError:
+                    setattr(result, str(k), True)
             except AttributeError:
                 raise ValidationError('Unknown choice: %r' % (k,))
         return int(result)


### PR DESCRIPTION
In my example, I had "Dänemark" (german for Denmark) as a choice. The problem is the line

```python
setattr(result, str(k), True)
````

in `forms.py`. If `k` is non-ascii unicode, then `str` will fail. My proposed solution is to always try to interpret `k` as unicode and then encode to `utf-8`, if Python 2 is used. This seems to work as intended (No `AttributeError` is raised) and while this admittetly also does not cover all use cases, it will work for most users.