### PR TITLE
Fix version lookup so bitfield.version stops always being unknown. plus

### DIFF
--- a/bitfield/__init__.py
+++ b/bitfield/__init__.py
@@ -9,6 +9,6 @@ from bitfield.models import Bit, BitHandler, CompositeBitField, BitField  # NOQA
 
 try:
     VERSION = __import__('pkg_resources') \
-        .get_distribution('bitfield').version
+        .get_distribution('django-bitfield').version
 except Exception:
     VERSION = 'unknown'


### PR DESCRIPTION
speed improvement.

before:

```
In [3]: time import bitfield
CPU times: user 39.4 ms, sys: 0 ns, total: 39.4 ms
Wall time: 39.4 ms

In [4]: bitfield.VERSION
Out[4]: 'unknown'
```

after:

```
In [3]: time import bitfield
CPU times: user 457 µs, sys: 56 µs, total: 513 µs
Wall time: 549 µs

In [4]: bitfield.VERSION
Out[4]: '1.8.0'
```
