### PR TITLE
better error if a flag key don't exist

### DIFF
--- a/bitfield/models.py
+++ b/bitfield/models.py
@@ -29,7 +29,7 @@ class BitFieldFlags(object):
 
     def __getattr__(self, key):
         if key not in self._flags:
-            raise AttributeError
+            raise AttributeError("flag {} is not registered".format(key))
         return Bit(self._flags.index(key))
 
     def iteritems(self):


### PR DESCRIPTION
I came across an AttributeError when a flag key don't exist. The associated message was not very clear and didn't really explained what was going on.

This pull request changes this error message to better express the missing flag by indicating that a flag, and which one, was not found.