### PR TITLE
Django 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '2.7'
 - '3.4'
 - '3.5'
+- '3.6'
 install: pip install flake8 tox-travis
 
 services:

--- a/bitfield/forms.py
+++ b/bitfield/forms.py
@@ -42,12 +42,12 @@ class BitFormField(IntegerField):
     def __init__(self, choices=(), widget=BitFieldCheckboxSelectMultiple, *args, **kwargs):
 
         if isinstance(kwargs['initial'], int):
-            iv = kwargs['initial']
-            l = []
+            initial = kwargs['initial']
+            flags = []
             for i in range(0, min(len(choices), 63)):
-                if (1 << i) & iv > 0:
-                    l += [choices[i][0]]
-            kwargs['initial'] = l
+                if (1 << i) & initial > 0:
+                    flags += [choices[i][0]]
+            kwargs['initial'] = flags
         self.widget = widget
         super(BitFormField, self).__init__(widget=widget, *args, **kwargs)
         self.choices = self.widget.choices = choices

--- a/bitfield/models.py
+++ b/bitfield/models.py
@@ -240,7 +240,12 @@ class CompositeBitField(object):
     def contribute_to_class(self, cls, name):
         self.name = name
         self.model = cls
-        cls._meta.virtual_fields.append(self)
+
+        # virtual_fields was deprecated in Django 1.10 and removed in 2.0
+        private_fields = getattr(cls._meta, "private_fields", None)
+        if private_fields is None:
+            private_fields = cls._meta.virtual_fields
+        private_fields.append(self)
 
         signals.class_prepared.connect(self.validate_fields, sender=cls)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
 envlist =
-    py27-django{14,15}-{sqlite,postgres}, py{27,34,35}-django{18,18,110}-{sqlite,postgres}
+  py27-django{14,15,18,19,110,111}-{sqlite,postgres}
+  py{34,35}-django{18,19,110,111,20}-{sqlite,postgres}
+  py36-django{111,20}-{sqlite,postgres}
 
 [testenv]
 commands =
-    py.test
+  py.test
 passenv = DB
 deps =
   pytest
@@ -19,6 +21,10 @@ deps =
   django19: pytest-django>=3.1
   django110: Django>=1.10,<1.11
   django110: pytest-django>=3.1
+  django111: Django>=1.11,<1.12
+  django111: pytest-django>=3.1
+  django20: Django>=2.0,<2.1
+  django20: pytest-django>=3.1
 setenv =
   sqlite: DB=sqlite
   postgres: DB=postgres


### PR DESCRIPTION
Support for Django 2.0

* `virtual_fields` has been replaced by `private_fields`. `private_fields` was added in 1.10, so check for its existence first and then fall back to `virtual_fields`
* Added missing Django versions to tox envlist (1.9 and 1.11 were missing)
* Fix indentation in tox.ini, some lines had 4-space indents, others had 2-space
* Fix lint error (only required to get Travis to pass)