### PR TITLE
Drop ancient Django versions, update tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
+- '3.7'
 install: pip install flake8 tox-travis
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '2.7'
 - '3.4'
 - '3.5'
+- '3.6'
 install: pip install flake8 tox-travis
 
 services:

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Provides a BitField like class (using a BigIntegerField) for your Django models.
 Requirements
 ============
 
-* Django >= 1.4
+* Django >= 1.8.19
 * PostgreSQL (see notes)
 
 **Notes:**

--- a/README.rst
+++ b/README.rst
@@ -107,3 +107,12 @@ To use it set ``list_filter`` ModelAdmin option::
 BitFieldListFilter is in ``bitfield.admin`` module::
 
     from bitfield.admin import BitFieldListFilter
+
+Changelog
+=========
+
+Scheduled for 2.0 release:
+
+- Drop support for Django versions below 1.10.
+- Use _meta.private_fields instead of deprecated _meta.virtual_fields in CompositeBitField.
+- Add testing with python 3.6, 3.7 and Django 2.x to travis configuration.

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Provides a BitField like class (using a BigIntegerField) for your Django models.
 Requirements
 ============
 
-* Django >= 1.8.19
+* Django >= 1.10.8
 * PostgreSQL (see notes)
 
 **Notes:**

--- a/bitfield/models.py
+++ b/bitfield/models.py
@@ -240,7 +240,7 @@ class CompositeBitField(object):
     def contribute_to_class(self, cls, name):
         self.name = name
         self.model = cls
-        cls._meta.virtual_fields.append(self)
+        cls._meta.private_fields.append(self)
 
         signals.class_prepared.connect(self.validate_fields, sender=cls)
 

--- a/bitfield/tests/tests.py
+++ b/bitfield/tests/tests.py
@@ -104,8 +104,8 @@ class BitTest(TestCase):
 
     def test_comparison(self):
         self.assertEqual(Bit(0), Bit(0))
-        self.assertNotEquals(Bit(1), Bit(0))
-        self.assertNotEquals(Bit(0, 0), Bit(0, 1))
+        self.assertNotEqual(Bit(1), Bit(0))
+        self.assertNotEqual(Bit(0, 0), Bit(0, 1))
         self.assertEqual(Bit(0, 1), Bit(0, 1))
         self.assertEqual(Bit(0), 1)
 

--- a/bitfield/tests/tests.py
+++ b/bitfield/tests/tests.py
@@ -357,7 +357,7 @@ class BitFormFieldTest(TestCase):
         ]
         for data in data_dicts:
             form = BitFieldTestModelForm(data=data)
-            self.failUnless(form.is_valid())
+            self.assertTrue(form.is_valid())
             instance = form.save()
             flags = data['flags'] if 'flags' in data else []
             for k in BitFieldTestModel.flags:
@@ -370,21 +370,21 @@ class BitFormFieldTest(TestCase):
 
         data = {'flags': ['FLAG_0', 'FLAG_1']}
         form = BitFieldTestModelForm(data=data, instance=instance)
-        self.failUnless(form.is_valid())
+        self.assertTrue(form.is_valid())
         instance = form.save()
         for k in BitFieldTestModel.flags:
             self.assertEquals(bool(getattr(instance.flags, k)), k in data['flags'])
 
         data = {'flags': ['FLAG_2', 'FLAG_3']}
         form = BitFieldTestModelForm(data=data, instance=instance)
-        self.failUnless(form.is_valid())
+        self.assertTrue(form.is_valid())
         instance = form.save()
         for k in BitFieldTestModel.flags:
             self.assertEquals(bool(getattr(instance.flags, k)), k in data['flags'])
 
         data = {'flags': []}
         form = BitFieldTestModelForm(data=data, instance=instance)
-        self.failUnless(form.is_valid())
+        self.assertTrue(form.is_valid())
         instance = form.save()
         for k in BitFieldTestModel.flags:
             self.assertFalse(bool(getattr(instance.flags, k)))

--- a/bitfield/tests/tests.py
+++ b/bitfield/tests/tests.py
@@ -25,117 +25,117 @@ class BitHandlerTest(TestCase):
     def test_defaults(self):
         bithandler = BitHandler(0, ('FLAG_0', 'FLAG_1', 'FLAG_2', 'FLAG_3'))
         # Default value of 0.
-        self.assertEquals(int(bithandler), 0)
+        self.assertEqual(int(bithandler), 0)
         # Test bit numbers.
-        self.assertEquals(int(bithandler.FLAG_0.number), 0)
-        self.assertEquals(int(bithandler.FLAG_1.number), 1)
-        self.assertEquals(int(bithandler.FLAG_2.number), 2)
-        self.assertEquals(int(bithandler.FLAG_3.number), 3)
+        self.assertEqual(int(bithandler.FLAG_0.number), 0)
+        self.assertEqual(int(bithandler.FLAG_1.number), 1)
+        self.assertEqual(int(bithandler.FLAG_2.number), 2)
+        self.assertEqual(int(bithandler.FLAG_3.number), 3)
         # Negative test non-existant key.
         self.assertRaises(AttributeError, lambda: bithandler.FLAG_4)
         # Test bool().
-        self.assertEquals(bool(bithandler.FLAG_0), False)
-        self.assertEquals(bool(bithandler.FLAG_1), False)
-        self.assertEquals(bool(bithandler.FLAG_2), False)
-        self.assertEquals(bool(bithandler.FLAG_3), False)
+        self.assertEqual(bool(bithandler.FLAG_0), False)
+        self.assertEqual(bool(bithandler.FLAG_1), False)
+        self.assertEqual(bool(bithandler.FLAG_2), False)
+        self.assertEqual(bool(bithandler.FLAG_3), False)
 
     def test_nonzero_default(self):
         bithandler = BitHandler(1, ('FLAG_0', 'FLAG_1', 'FLAG_2', 'FLAG_3'))
-        self.assertEquals(bool(bithandler.FLAG_0), True)
-        self.assertEquals(bool(bithandler.FLAG_1), False)
-        self.assertEquals(bool(bithandler.FLAG_2), False)
-        self.assertEquals(bool(bithandler.FLAG_3), False)
+        self.assertEqual(bool(bithandler.FLAG_0), True)
+        self.assertEqual(bool(bithandler.FLAG_1), False)
+        self.assertEqual(bool(bithandler.FLAG_2), False)
+        self.assertEqual(bool(bithandler.FLAG_3), False)
 
         bithandler = BitHandler(2, ('FLAG_0', 'FLAG_1', 'FLAG_2', 'FLAG_3'))
-        self.assertEquals(bool(bithandler.FLAG_0), False)
-        self.assertEquals(bool(bithandler.FLAG_1), True)
-        self.assertEquals(bool(bithandler.FLAG_2), False)
-        self.assertEquals(bool(bithandler.FLAG_3), False)
+        self.assertEqual(bool(bithandler.FLAG_0), False)
+        self.assertEqual(bool(bithandler.FLAG_1), True)
+        self.assertEqual(bool(bithandler.FLAG_2), False)
+        self.assertEqual(bool(bithandler.FLAG_3), False)
 
         bithandler = BitHandler(3, ('FLAG_0', 'FLAG_1', 'FLAG_2', 'FLAG_3'))
-        self.assertEquals(bool(bithandler.FLAG_0), True)
-        self.assertEquals(bool(bithandler.FLAG_1), True)
-        self.assertEquals(bool(bithandler.FLAG_2), False)
-        self.assertEquals(bool(bithandler.FLAG_3), False)
+        self.assertEqual(bool(bithandler.FLAG_0), True)
+        self.assertEqual(bool(bithandler.FLAG_1), True)
+        self.assertEqual(bool(bithandler.FLAG_2), False)
+        self.assertEqual(bool(bithandler.FLAG_3), False)
 
         bithandler = BitHandler(4, ('FLAG_0', 'FLAG_1', 'FLAG_2', 'FLAG_3'))
-        self.assertEquals(bool(bithandler.FLAG_0), False)
-        self.assertEquals(bool(bithandler.FLAG_1), False)
-        self.assertEquals(bool(bithandler.FLAG_2), True)
-        self.assertEquals(bool(bithandler.FLAG_3), False)
+        self.assertEqual(bool(bithandler.FLAG_0), False)
+        self.assertEqual(bool(bithandler.FLAG_1), False)
+        self.assertEqual(bool(bithandler.FLAG_2), True)
+        self.assertEqual(bool(bithandler.FLAG_3), False)
 
     def test_mutation(self):
         bithandler = BitHandler(0, ('FLAG_0', 'FLAG_1', 'FLAG_2', 'FLAG_3'))
-        self.assertEquals(bool(bithandler.FLAG_0), False)
-        self.assertEquals(bool(bithandler.FLAG_1), False)
-        self.assertEquals(bool(bithandler.FLAG_2), False)
-        self.assertEquals(bool(bithandler.FLAG_3), False)
+        self.assertEqual(bool(bithandler.FLAG_0), False)
+        self.assertEqual(bool(bithandler.FLAG_1), False)
+        self.assertEqual(bool(bithandler.FLAG_2), False)
+        self.assertEqual(bool(bithandler.FLAG_3), False)
 
         bithandler = BitHandler(bithandler | 1, bithandler._keys)
-        self.assertEquals(bool(bithandler.FLAG_0), True)
-        self.assertEquals(bool(bithandler.FLAG_1), False)
-        self.assertEquals(bool(bithandler.FLAG_2), False)
-        self.assertEquals(bool(bithandler.FLAG_3), False)
+        self.assertEqual(bool(bithandler.FLAG_0), True)
+        self.assertEqual(bool(bithandler.FLAG_1), False)
+        self.assertEqual(bool(bithandler.FLAG_2), False)
+        self.assertEqual(bool(bithandler.FLAG_3), False)
 
         bithandler ^= 3
-        self.assertEquals(int(bithandler), 2)
+        self.assertEqual(int(bithandler), 2)
 
-        self.assertEquals(bool(bithandler & 1), False)
+        self.assertEqual(bool(bithandler & 1), False)
 
         bithandler.FLAG_0 = False
-        self.assertEquals(bithandler.FLAG_0, False)
+        self.assertEqual(bithandler.FLAG_0, False)
 
         bithandler.FLAG_1 = True
-        self.assertEquals(bithandler.FLAG_0, False)
-        self.assertEquals(bithandler.FLAG_1, True)
+        self.assertEqual(bithandler.FLAG_0, False)
+        self.assertEqual(bithandler.FLAG_1, True)
 
         bithandler.FLAG_2 = False
-        self.assertEquals(bithandler.FLAG_0, False)
-        self.assertEquals(bithandler.FLAG_1, True)
-        self.assertEquals(bithandler.FLAG_2, False)
+        self.assertEqual(bithandler.FLAG_0, False)
+        self.assertEqual(bithandler.FLAG_1, True)
+        self.assertEqual(bithandler.FLAG_2, False)
 
 
 class BitTest(TestCase):
     def test_int(self):
         bit = Bit(0)
-        self.assertEquals(int(bit), 1)
-        self.assertEquals(bool(bit), True)
+        self.assertEqual(int(bit), 1)
+        self.assertEqual(bool(bit), True)
         self.assertFalse(not bit)
 
     def test_comparison(self):
-        self.assertEquals(Bit(0), Bit(0))
+        self.assertEqual(Bit(0), Bit(0))
         self.assertNotEquals(Bit(1), Bit(0))
         self.assertNotEquals(Bit(0, 0), Bit(0, 1))
-        self.assertEquals(Bit(0, 1), Bit(0, 1))
-        self.assertEquals(Bit(0), 1)
+        self.assertEqual(Bit(0, 1), Bit(0, 1))
+        self.assertEqual(Bit(0), 1)
 
     def test_and(self):
-        self.assertEquals(1 & Bit(2), 0)
-        self.assertEquals(1 & Bit(0), 1)
-        self.assertEquals(1 & ~Bit(0), 0)
-        self.assertEquals(Bit(0) & Bit(2), 0)
-        self.assertEquals(Bit(0) & Bit(0), 1)
-        self.assertEquals(Bit(0) & ~Bit(0), 0)
+        self.assertEqual(1 & Bit(2), 0)
+        self.assertEqual(1 & Bit(0), 1)
+        self.assertEqual(1 & ~Bit(0), 0)
+        self.assertEqual(Bit(0) & Bit(2), 0)
+        self.assertEqual(Bit(0) & Bit(0), 1)
+        self.assertEqual(Bit(0) & ~Bit(0), 0)
 
     def test_or(self):
-        self.assertEquals(1 | Bit(2), 5)
-        self.assertEquals(1 | Bit(5), 33)
-        self.assertEquals(1 | ~Bit(2), -5)
-        self.assertEquals(Bit(0) | Bit(2), 5)
-        self.assertEquals(Bit(0) | Bit(5), 33)
-        self.assertEquals(Bit(0) | ~Bit(2), -5)
+        self.assertEqual(1 | Bit(2), 5)
+        self.assertEqual(1 | Bit(5), 33)
+        self.assertEqual(1 | ~Bit(2), -5)
+        self.assertEqual(Bit(0) | Bit(2), 5)
+        self.assertEqual(Bit(0) | Bit(5), 33)
+        self.assertEqual(Bit(0) | ~Bit(2), -5)
 
     def test_xor(self):
-        self.assertEquals(1 ^ Bit(2), 5)
-        self.assertEquals(1 ^ Bit(0), 0)
-        self.assertEquals(1 ^ Bit(1), 3)
-        self.assertEquals(1 ^ Bit(5), 33)
-        self.assertEquals(1 ^ ~Bit(2), -6)
-        self.assertEquals(Bit(0) ^ Bit(2), 5)
-        self.assertEquals(Bit(0) ^ Bit(0), 0)
-        self.assertEquals(Bit(0) ^ Bit(1), 3)
-        self.assertEquals(Bit(0) ^ Bit(5), 33)
-        self.assertEquals(Bit(0) ^ ~Bit(2), -6)
+        self.assertEqual(1 ^ Bit(2), 5)
+        self.assertEqual(1 ^ Bit(0), 0)
+        self.assertEqual(1 ^ Bit(1), 3)
+        self.assertEqual(1 ^ Bit(5), 33)
+        self.assertEqual(1 ^ ~Bit(2), -6)
+        self.assertEqual(Bit(0) ^ Bit(2), 5)
+        self.assertEqual(Bit(0) ^ Bit(0), 0)
+        self.assertEqual(Bit(0) ^ Bit(1), 3)
+        self.assertEqual(Bit(0) ^ Bit(5), 33)
+        self.assertEqual(Bit(0) ^ ~Bit(2), -6)
 
 
 class BitFieldTest(TestCase):
@@ -256,7 +256,7 @@ class BitFieldTest(TestCase):
         except ValueError:
             self.fail("It should work well with these flags")
 
-        self.assertEquals(bf.flags, ['zero', 'first', 'second', '', '', '', '', '', '', '', 'tenth'])
+        self.assertEqual(bf.flags, ['zero', 'first', 'second', '', '', '', '', '', '', '', 'tenth'])
         self.assertRaises(ValueError, BitField, flags={})
         self.assertRaises(ValueError, BitField, flags={'wrongkey': 'wrongkey'})
         self.assertRaises(ValueError, BitField, flags={'1': 'non_int_key'})
@@ -270,7 +270,7 @@ class BitFieldTest(TestCase):
                 'FLAG_3',
             ), default=('FLAG_1', 'FLAG_2'))
         field = TestModel._meta.get_field('flags')
-        self.assertEquals(field.default, TestModel.flags.FLAG_1 | TestModel.flags.FLAG_2)
+        self.assertEqual(field.default, TestModel.flags.FLAG_1 | TestModel.flags.FLAG_2)
 
 
 class BitFieldSerializationTest(TestCase):
@@ -287,8 +287,8 @@ class BitFieldSerializationTest(TestCase):
         inst = BitFieldTestModel.objects.create(flags=1)
         data = pickle.dumps(inst)
         inst = pickle.loads(data)
-        self.assertEquals(type(inst.flags), BitHandler)
-        self.assertEquals(int(inst.flags), 1)
+        self.assertEqual(type(inst.flags), BitHandler)
+        self.assertEqual(int(inst.flags), 1)
 
     def test_added_field(self):
         bf = BitFieldTestModel()
@@ -361,7 +361,7 @@ class BitFormFieldTest(TestCase):
             instance = form.save()
             flags = data['flags'] if 'flags' in data else []
             for k in BitFieldTestModel.flags:
-                self.assertEquals(bool(getattr(instance.flags, k)), k in flags)
+                self.assertEqual(bool(getattr(instance.flags, k)), k in flags)
 
     def test_form_update(self):
         instance = BitFieldTestModel.objects.create(flags=0)
@@ -373,14 +373,14 @@ class BitFormFieldTest(TestCase):
         self.assertTrue(form.is_valid())
         instance = form.save()
         for k in BitFieldTestModel.flags:
-            self.assertEquals(bool(getattr(instance.flags, k)), k in data['flags'])
+            self.assertEqual(bool(getattr(instance.flags, k)), k in data['flags'])
 
         data = {'flags': ['FLAG_2', 'FLAG_3']}
         form = BitFieldTestModelForm(data=data, instance=instance)
         self.assertTrue(form.is_valid())
         instance = form.save()
         for k in BitFieldTestModel.flags:
-            self.assertEquals(bool(getattr(instance.flags, k)), k in data['flags'])
+            self.assertEqual(bool(getattr(instance.flags, k)), k in data['flags'])
 
         data = {'flags': []}
         form = BitFieldTestModelForm(data=data, instance=instance)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=[
-        'Django>=1.8.19',
+        'Django>=1.10.8',
         'six',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=[
-        'Django>=1.4.22',
+        'Django>=1.8.19',
         'six',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35}-django{18,19,110,111}-{sqlite,postgres}
+    py{27,34,35,36}-django{18,19,110,111}-{sqlite,postgres}
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django{110,111}-{sqlite,postgres}
+    py{27,34,35,36}-django{110,111}-{sqlite,postgres}, py{34,35,36}-django{20}-{sqlite,postgres},
+    py{35,36}-django{21,22}-{sqlite,postgres}
 
 [testenv]
 commands =
@@ -13,6 +14,12 @@ deps =
   django110: pytest-django>=3.1
   django111: Django>=1.11,<1.12
   django111: pytest-django>=3.1
+  django20: Django>=2.0,<2.1
+  django20: pytest-django>=3.1
+  django21: Django>=2.1,<2.2
+  django21: pytest-django>=3.1
+  django22: Django>=2.2,<2.3
+  django22: pytest-django>=3.1
 setenv =
   sqlite: DB=sqlite
   postgres: DB=postgres

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django{110,111}-{sqlite,postgres}, py{34,35,36}-django{20}-{sqlite,postgres},
-    py{35,36}-django{21,22}-{sqlite,postgres}
+    py{27,34,35,36}-django{110,111}-{sqlite,postgres}, py{34,35,36,37}-django{20}-{sqlite,postgres},
+    py{35,36,37}-django{21,22}-{sqlite,postgres}
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35}-django{18,18,110}-{sqlite,postgres}
+    py{27,34,35}-django{18,19,110}-{sqlite,postgres}
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35}-django{18,19,110}-{sqlite,postgres}
+    py{27,34,35}-django{18,19,110,111}-{sqlite,postgres}
 
 [testenv]
 commands =
@@ -15,6 +15,8 @@ deps =
   django19: pytest-django>=3.1
   django110: Django>=1.10,<1.11
   django110: pytest-django>=3.1
+  django111: Django>=1.11,<1.12
+  django111: pytest-django>=3.1
 setenv =
   sqlite: DB=sqlite
   postgres: DB=postgres

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27-django{14,15}-{sqlite,postgres}, py{27,34,35}-django{18,18,110}-{sqlite,postgres}
+    py{27,34,35}-django{18,18,110}-{sqlite,postgres}
 
 [testenv]
 commands =
@@ -9,10 +9,6 @@ passenv = DB
 deps =
   pytest
   psycopg2>=2.3
-  django14: Django>=1.4.22,<1.5
-  django14: pytest-django==2.9.1
-  django15: Django>=1.5,<1.6
-  django15: pytest-django==2.9.1
   django18: Django>=1.8,<1.9
   django18: pytest-django>=3.1
   django19: Django>=1.9,<1.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django{18,19,110,111}-{sqlite,postgres}
+    py{27,34,35,36}-django{110,111}-{sqlite,postgres}
 
 [testenv]
 commands =
@@ -9,10 +9,6 @@ passenv = DB
 deps =
   pytest
   psycopg2>=2.3
-  django18: Django>=1.8,<1.9
-  django18: pytest-django>=3.1
-  django19: Django>=1.9,<1.10
-  django19: pytest-django>=3.1
   django110: Django>=1.10,<1.11
   django110: pytest-django>=3.1
   django111: Django>=1.11,<1.12


### PR DESCRIPTION
First commit fixes python 2.7 failures https://github.com/disqus/django-bitfield/issues/90 which were caused by pytest-django for django 1.4, 1.5 using deprecated methods.

Then some cleanups in tests to get rid of deprecation warnings.

Testing with django 1.11 as well as python 3.6 is added in travis config, to make things more up-to-date. 

Required Django version is bumped to >= 1.8.19, but it probably makes sense to go further in future PRs and drop everything under 1.11, as Django no longers maintains any of those versions. 
