### PR TITLE
Remove some dead compatibility logic

### DIFF
--- a/bitfield/compat.py
+++ b/bitfield/compat.py
@@ -9,19 +9,3 @@ def bitand(a, b):
 
 def bitor(a, b):
     return a.bitor(b)
-
-
-try:
-    from django.db.models.expressions import ExpressionNode
-    ExpressionNode.BITAND  # noqa
-    del ExpressionNode
-except ImportError:
-    # Django >= 1.8
-    pass
-except AttributeError:
-    # Django < 1.5
-    def bitand(a, b):  # NOQA
-        return a & b
-
-    def bitor(a, b):  # NOQA
-        return a | b

--- a/bitfield/query.py
+++ b/bitfield/query.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from bitfield.types import Bit, BitHandler
+from django.db.models.lookups import Exact
 
 
 class BitQueryLookupWrapper(object):
@@ -23,30 +24,23 @@ class BitQueryLookupWrapper(object):
                 [])
 
 
-try:
-    # Django 1.7+
-    from django.db.models.lookups import Exact
+class BitQueryLookupWrapper(Exact):  # NOQA
+    def process_lhs(self, qn, connection, lhs=None):
+        lhs_sql, params = super(BitQueryLookupWrapper, self).process_lhs(
+            qn, connection, lhs)
+        if self.rhs:
+            lhs_sql = lhs_sql + ' & %s'
+        else:
+            lhs_sql = lhs_sql + ' | %s'
+        params.extend(self.get_db_prep_lookup(self.rhs, connection)[1])
+        return lhs_sql, params
 
-    class BitQueryLookupWrapper(Exact):  # NOQA
-        def process_lhs(self, qn, connection, lhs=None):
-            lhs_sql, params = super(BitQueryLookupWrapper, self).process_lhs(
-                qn, connection, lhs)
-            if self.rhs:
-                lhs_sql = lhs_sql + ' & %s'
-            else:
-                lhs_sql = lhs_sql + ' | %s'
-            params.extend(self.get_db_prep_lookup(self.rhs, connection)[1])
-            return lhs_sql, params
+    def get_db_prep_lookup(self, value, connection, prepared=False):
+        v = value.mask if isinstance(value, (BitHandler, Bit)) else value
+        return super(BitQueryLookupWrapper, self).get_db_prep_lookup(v, connection)
 
-        def get_db_prep_lookup(self, value, connection, prepared=False):
-            v = value.mask if isinstance(value, (BitHandler, Bit)) else value
-            return super(BitQueryLookupWrapper, self).get_db_prep_lookup(v, connection)
-
-        def get_prep_lookup(self):
-            return self.rhs
-
-except ImportError:
-    pass
+    def get_prep_lookup(self):
+        return self.rhs
 
 
 class BitQuerySaveWrapper(BitQueryLookupWrapper):

--- a/bitfield/types.py
+++ b/bitfield/types.py
@@ -245,23 +245,20 @@ class BitHandler(object):
         return self._labels[flag]
 
 
-import django
+from django.core.exceptions import ImproperlyConfigured
 
-if django.VERSION[:2] >= (1, 8):
-    from django.core.exceptions import ImproperlyConfigured
+# We need to register adapters in order to prevent
+# "ProgrammingError: can't adapt type"
+try:
+    from django.db.backends.sqlite3.base import Database
+    Database.register_adapter(Bit, lambda x: int(x))
+    Database.register_adapter(BitHandler, lambda x: int(x))
+except ImproperlyConfigured:
+    pass
 
-    # We need to register adapters in Django 1.8 in order to prevent
-    # "ProgrammingError: can't adapt type"
-    try:
-        from django.db.backends.sqlite3.base import Database
-        Database.register_adapter(Bit, lambda x: int(x))
-        Database.register_adapter(BitHandler, lambda x: int(x))
-    except ImproperlyConfigured:
-        pass
-
-    try:
-        from django.db.backends.postgresql_psycopg2.base import Database
-        Database.extensions.register_adapter(Bit, lambda x: Database.extensions.AsIs(int(x)))
-        Database.extensions.register_adapter(BitHandler, lambda x: Database.extensions.AsIs(int(x)))
-    except ImproperlyConfigured:
-        pass
+try:
+    from django.db.backends.postgresql_psycopg2.base import Database
+    Database.extensions.register_adapter(Bit, lambda x: Database.extensions.AsIs(int(x)))
+    Database.extensions.register_adapter(BitHandler, lambda x: Database.extensions.AsIs(int(x)))
+except ImproperlyConfigured:
+    pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,7 @@
 [tox]
+# Run Django versions with the Python versions that they support.
+# Taken from:
+# https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 envlist =
     py{27,34,35,36}-django{110,111}-{sqlite,postgres}, py{34,35,36,37}-django{20}-{sqlite,postgres},
     py{35,36,37}-django{21,22}-{sqlite,postgres}


### PR DESCRIPTION
Since we dropped a bunch of old Django versions, there is no more need for various old compatibility logic which did/imported various things based on Django version.

Plus a commit adding a note to tox.ini about why we test these specific python versions with these specific django versions, since this seems to warrant an explanation.