### PR TITLE
types.py: alias for psycopg2 removed with Django 3.0

### DIFF
--- a/bitfield/types.py
+++ b/bitfield/types.py
@@ -257,7 +257,10 @@ except ImproperlyConfigured:
     pass
 
 try:
-    from django.db.backends.postgresql_psycopg2.base import Database
+    if django.VERSION[:2] >= (1, 9):
+        from django.db.backends.postgresql.base import Database
+    else:
+        from django.db.backends.postgresql_psycopg2.base import Database
     Database.extensions.register_adapter(Bit, lambda x: Database.extensions.AsIs(int(x)))
     Database.extensions.register_adapter(BitHandler, lambda x: Database.extensions.AsIs(int(x)))
 except ImproperlyConfigured:

--- a/bitfield/types.py
+++ b/bitfield/types.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from six import string_types
 
+from django import VERSION as django_version
+
 
 def cmp(a, b):
     return (a > b) - (a < b)
@@ -257,7 +259,7 @@ except ImproperlyConfigured:
     pass
 
 try:
-    if django.VERSION[:2] >= (1, 9):
+    if django_version[:2] >= (1, 9):
         from django.db.backends.postgresql.base import Database
     else:
         from django.db.backends.postgresql_psycopg2.base import Database


### PR DESCRIPTION
Django 3.0 dropped alias for postgresql_psycopg2 -> postgresql