### PR TITLE
BitQuerySaveWrapper: avoid race, support SQLite

### DIFF
--- a/bitfield/query.py
+++ b/bitfield/query.py
@@ -24,23 +24,19 @@ class BitQueryLookupWrapper(Exact):  # NOQA
 
 
 class BitQuerySaveWrapper(BitQueryLookupWrapper):
-    def as_sql(self, qn, connection):
+    def as_sql(self, compiler, connection):
         """
         Create the proper SQL fragment. This inserts something like
         "(T0.flags & value) != 0".
 
         This will be called by Where.as_sql()
         """
-        engine = connection.settings_dict['ENGINE'].rsplit('.', -1)[-1]
-        if engine.startswith('postgres'):
-            XOR_OPERATOR = '#'
-        elif engine.startswith('sqlite'):
-            raise NotImplementedError
-        else:
-            XOR_OPERATOR = '^'
+        op = '|' if self.bit else '&~'
+        qn = compiler.quote_name_unless_alias
+        return ("%s.%s %s %d" % (qn(self.table_alias), qn(self.column), op, self.bit.mask), [])
 
-        if self.bit:
-            return ("%s.%s | %d" % (qn(self.table_alias), qn(self.column), self.bit.mask),
-                    [])
-        return ("%s.%s %s %d" % (qn(self.table_alias), qn(self.column), XOR_OPERATOR, self.bit.mask),
-                [])
+    def as_oracle(self, compiler, connection):
+        if not self.bit:
+            qn = compiler.quote_name_unless_alias
+            return ("%s.%s & (-(%d)-1)" % (qn(self.table_alias), qn(self.column), self.bit.mask), [])
+        return self.as_sql(compiler, connection)


### PR DESCRIPTION
Bitwise NOT operator shall sign-extend to fit LHS.

The operator seems to be supported in pretty much all engines except Oracle.

Also, use quote_name_unless_alias instead of deprecated `compiler.__call__`.