### PR TITLE
models: remove obsolete method overrides

### DIFF
--- a/bitfield/models.py
+++ b/bitfield/models.py
@@ -116,13 +116,6 @@ class BitField(BigIntegerField):
         self.flags = flags
         self.labels = labels
 
-    def south_field_triple(self):
-        "Returns a suitable description of this field for South."
-        from south.modelsinspector import introspector
-        field_class = "django.db.models.fields.BigIntegerField"
-        args, kwargs = introspector(self)
-        return (field_class, args, kwargs)
-
     def formfield(self, form_class=BitFormField, **kwargs):
         choices = [(k, self.labels[self.flags.index(k)]) for k in self.flags]
         return Field.formfield(self, form_class, choices=choices, **kwargs)
@@ -142,27 +135,6 @@ class BitField(BigIntegerField):
     #     if isinstance(value, Bit):
     #         return BitQuerySaveWrapper(self.model._meta.db_table, self.name, value)
     #     return super(BitField, self).get_db_prep_save(value, connection=connection)
-
-    def get_db_prep_lookup(self, lookup_type, value, connection, prepared=False):
-        if isinstance(getattr(value, 'expression', None), Bit):
-            value = value.expression
-        if isinstance(value, (BitHandler, Bit)):
-            if hasattr(self, 'class_lookups'):
-                # Django 1.7+
-                return [value.mask]
-            else:
-                return BitQueryLookupWrapper(self.model._meta.db_table, self.db_column or self.name, value)
-        return BigIntegerField.get_db_prep_lookup(self, lookup_type=lookup_type, value=value,
-                                                  connection=connection, prepared=prepared)
-
-    def get_prep_lookup(self, lookup_type, value):
-        if isinstance(getattr(value, 'expression', None), Bit):
-            value = value.expression
-        if isinstance(value, Bit):
-            if lookup_type in ('exact',):
-                return value
-            raise TypeError('Lookup type %r not supported with `Bit` type.' % lookup_type)
-        return BigIntegerField.get_prep_lookup(self, lookup_type, value)
 
     def to_python(self, value):
         if isinstance(value, Bit):


### PR DESCRIPTION
From Django 1.7 release notes:

    Schema migrations
    -----------------

    Django now has built-in support for schema migrations. It allows models
    to be updated, changed, and deleted by creating migration files that represent
    the model changes and which can be run on any development, staging or production
    database.
    Django 1.7 replaced South with its own migration framework.

From Django 1.10 release notes:

    ``Field.get_prep_lookup()`` and ``Field.get_db_prep_lookup()`` methods are removed
    ----------------------------------------------------------------------------------

    If you have a custom field that implements either of these methods, register a
    custom lookup for it. For example::

        from django.db.models import Field
        from django.db.models.lookups import Exact

        class MyField(Field):
            ...

        class MyFieldExact(Exact):
            def get_prep_lookup(self):
                # do_custom_stuff_for_myfield
                ....

        MyField.register_lookup(MyFieldExact)