### PR TITLE
models: remove unnecessary BitField.pre_save

### DIFF
--- a/bitfield/models.py
+++ b/bitfield/models.py
@@ -127,10 +127,6 @@ class BitField(BigIntegerField):
         choices = [(k, self.labels[self.flags.index(k)]) for k in self.flags]
         return Field.formfield(self, form_class, choices=choices, **kwargs)
 
-    def pre_save(self, instance, add):
-        value = getattr(instance, self.attname)
-        return value
-
     def get_prep_value(self, value):
         if value is None:
             return None


### PR DESCRIPTION
The code already equaled the default implementation.

Probably ended up from some tinkering that eventually resulted in reverting back to the default behavior.