### PR TITLE
forms: rename _has_changed to has_changed

### DIFF
--- a/bitfield/forms.py
+++ b/bitfield/forms.py
@@ -23,7 +23,7 @@ class BitFieldCheckboxSelectMultiple(CheckboxSelectMultiple):
         return super(BitFieldCheckboxSelectMultiple, self).render(
             name, value, attrs=attrs)
 
-    def _has_changed(self, initial, data):
+    def has_changed(self, initial, data):
         if initial is None:
             initial = []
         if data is None:


### PR DESCRIPTION
The `_has_changed` had been deprecated in 1.6 and compatibility shim for it has been removed way back in 1.10. Fixes the regression and restores the change detection behavior.