### PR TITLE
Fix Travis CI test errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 - '3.5'
 - '3.6'
 - '3.7'
+- '3.8'
+- '3.9'
 install: pip install flake8 tox-travis
 
 services:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 envlist =
     py{27,34,35,36}-django{110,111}-{sqlite,postgres}, py{34,35,36,37}-django{20}-{sqlite,postgres},
-    py{35,36,37}-django{21,22}-{sqlite,postgres}, py{36,37}-django{30}-{sqlite,postgres}
+    py{35,36,37}-django{21,22}-{sqlite,postgres}, py{36,37}-django{30,31}-{sqlite,postgres}
 
 [testenv]
 commands =
@@ -25,6 +25,8 @@ deps =
   django22: pytest-django>=3.1
   django30: Django>=3.0,<3.1
   django30: pytest-django>=3.1
+  django31: Django>=3.1,<3.2
+  django31: pytest-django>=3.1
 setenv =
   sqlite: DB=sqlite
   postgres: DB=postgres

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@
 # Taken from:
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py{27,34,35,36}-django{110,111}-{sqlite,postgres}, py{34,35,36,37}-django{20}-{sqlite,postgres},
-    py{35,36,37}-django{21,22}-{sqlite,postgres}, py{36,37}-django{30,31}-{sqlite,postgres}
+    py{27,34,35,36}-django{110,111}-{sqlite,postgres}, py{34,35,36,37,38,39}-django{20}-{sqlite,postgres},
+    py{35,36,37,38,39}-django{21,22}-{sqlite,postgres}, py{36,37,38,39}-django{30,31}-{sqlite,postgres}
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,9 @@ deps =
   pytest
   psycopg2>=2.3
   django110: Django>=1.10,<1.11
-  django110: pytest-django>=3.1
+  django110: pytest-django>=3.1,<4.0
   django111: Django>=1.11,<1.12
-  django111: pytest-django>=3.1
+  django111: pytest-django>=3.1,<4.0
   django20: Django>=2.0,<2.1
   django20: pytest-django>=3.1
   django21: Django>=2.1,<2.2


### PR DESCRIPTION
[pytest-django](https://pypi.org/project/pytest-django/) 4.x dropped support for Django <2.0.

Also, add [Django 3.1](https://docs.djangoproject.com/en/3.1/releases/) and Python [3.8](https://www.python.org/downloads/release/python-380/) and [3.9](https://www.python.org/downloads/release/python-390/) to `tox.ini`.

Fixes #114.