### PR TITLE
Fix Deprecation warning for ugettext_lazy

### DIFF
--- a/bitfield/admin.py
+++ b/bitfield/admin.py
@@ -1,7 +1,12 @@
+import django
 import six
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+if django.VERSION < (2, 0):
+    from django.utils.translation import ugettext_lazy as _
+else:
+    # Aliased since Django 2.0 https://github.com/django/django/blob/2.0/django/utils/translation/__init__.py#L80-L81
+    from django.utils.translation import gettext_lazy as _
 from django.contrib.admin import FieldListFilter
 from django.contrib.admin.options import IncorrectLookupParameters
 


### PR DESCRIPTION
Fixes this deprecation warning:
`/usr/local/lib/python3.9/site-packages/bitfield/admin.py:43: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().`