### PR TITLE
Fix deprecation: Change force_text to force_str

### DIFF
--- a/bitfield/forms.py
+++ b/bitfield/forms.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.forms import CheckboxSelectMultiple, IntegerField, ValidationError
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from bitfield.types import BitHandler
 
@@ -30,8 +30,8 @@ class BitFieldCheckboxSelectMultiple(CheckboxSelectMultiple):
             data = []
         if initial != data:
             return True
-        initial_set = set([force_text(value) for value in initial])
-        data_set = set([force_text(value) for value in data])
+        initial_set = set([force_str(value) for value in initial])
+        data_set = set([force_str(value) for value in data])
         return data_set != initial_set
 
 

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,6 @@ setup(
         'Operating System :: OS Independent',
         'Topic :: Software Development',
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@
 # Taken from:
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py{27,34,35,36}-django{110,111}-{sqlite,postgres}, py{34,35,36,37,38,39}-django{20}-{sqlite,postgres},
-    py{35,36,37,38,39}-django{21,22}-{sqlite,postgres}, py{36,37,38,39}-django{30,31,32}-{sqlite,postgres}
+    py{34,35,36}-django{110,111}-{sqlite,postgres}, py{34,35,36,37,38,39}-django{20}-{sqlite,postgres},
+    py{35,36,37,38,39}-django{21,22}-{sqlite,postgres}, py{36,37,38,39,310}-django{30,31,32,40}-{sqlite,postgres}
 
 [testenv]
 commands =
@@ -12,7 +12,7 @@ commands =
 passenv = DB
 deps =
   pytest
-  psycopg2>=2.3
+  psycopg2-binary>=2.9
   py34: typing
   django110: Django>=1.10,<1.11
   django110: pytest-django>=3.1,<4.0
@@ -30,6 +30,8 @@ deps =
   django31: pytest-django>=3.10
   django32: Django>=3.2,<3.3
   django32: pytest-django>=4.2
+  django40: Django>=4.0,<4.1
+  django40: pytest-django>=4.5
 setenv =
   sqlite: DB=sqlite
   postgres: DB=postgres


### PR DESCRIPTION
This is not a breaking change for Python 3. force_str has existed at least as far back as Django 1.8.

If Python 2 support is needed, then this could break it. IMO it shouldn't be supported but if preferred I can wrap this in a try catch.