### PR TITLE
tox: Finish removing Django 1.10 environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # Taken from:
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py{35,36}-django{110,111}-{sqlite,postgres},
+    py{35,36}-django{111}-{sqlite,postgres},
     py{35,36,37,38,39}-django{20}-{sqlite,postgres},
     py{35,36,37,38,39}-django{21,22}-{sqlite,postgres},
     py{36,37,38,39,310}-django{30,31,32}-{sqlite,postgres},


### PR DESCRIPTION
This was missed in commit 8e42237acfd07ea334983b2daf388bf2057abc6a.