### PR TITLE
Test only currentlty supported Django versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     steps:
       - name: Set up PostgreSQL
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.5"
-          - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/tox.ini
+++ b/tox.ini
@@ -3,20 +3,15 @@
 # Taken from:
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py{35,36}-django{111}-{sqlite,postgres},
-    py{35,36,37,38,39}-django{20}-{sqlite,postgres},
-    py{35,36,37,38,39}-django{21,22}-{sqlite,postgres},
-    py{36,37,38,39,310}-django{30,31,32}-{sqlite,postgres},
-    py{38,39,310}-django{40}-{sqlite,postgres},
+    py{38,39,310}-django{32,40,41}-{sqlite,postgres},
+    py{38,39,310,311}-django{41}-{sqlite,postgres},
 
 [gh-actions]
 python =
-    3.5: py35
-    3.6: py36
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 commands =
@@ -25,22 +20,12 @@ passenv = DB
 deps =
   pytest
   psycopg2-binary>=2.8
-  django111: Django>=1.11,<1.12
-  django111: pytest-django>=3.1,<4.0
-  django20: Django>=2.0,<2.1
-  django20: pytest-django>=3.1
-  django21: Django>=2.1,<2.2
-  django21: pytest-django>=3.1
-  django22: Django>=2.2,<2.3
-  django22: pytest-django>=3.1
-  django30: Django>=3.0,<3.1
-  django30: pytest-django>=3.1
-  django31: Django>=3.1,<3.2
-  django31: pytest-django>=3.10
   django32: Django>=3.2,<3.3
   django32: pytest-django>=4.2
   django40: Django>=4.0,<4.1
   django40: pytest-django>=4.5
+  django41: Django>=4.1,<4.2
+  django41: pytest-django>=4.5
 setenv =
   sqlite: DB=sqlite
   postgres: DB=postgres


### PR DESCRIPTION
I decided to support only Python versions supported in the GitHub CI "ubuntu-latest" which is 22.04 at this time. IMO, with our limited time, it's better to test less versions and prioritize Django 4.2 support and passing CI tests. Folks are welcome to hold off on upgrading.