### PR TITLE
Exclude tests in sdist build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include setup.py README MANIFEST.in LICENSE
 global-exclude *~
+exclude bitfield/tests/*


### PR DESCRIPTION
Fixes #124 

Note this only affects source distributions (not wheels). Since only sdist are published, that shouldn't matter.

If for some reason we wanted to build wheels, I might advise switching to a newer build system like the pyproject.toml standard + Poetry. I would consider helping if there was interest.