### PR TITLE
setup: Fix DeprecationWarning from ast

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ class GetVersion(ast.NodeVisitor):
     def visit_Assign(self, node):
         if any(target.id == 'VERSION' for target in node.targets):
             assert not hasattr(self, 'VERSION')
-            self.VERSION = node.value.s
+            self.VERSION = node.value.value
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, 'README.rst')) as f:


### PR DESCRIPTION
`DeprecationWarning: Attribute s is deprecated and will be removed in Python 3.14; use value instead`

`value` was added in Python 3.8, due to `ast.Str` being replaced with `ast.Constant`: https://docs.python.org/3/whatsnew/3.8.html#deprecated